### PR TITLE
Don't override jackson-databind version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,7 +28,6 @@
         <aws-java-sdk-dynamodb.version>1.11.834</aws-java-sdk-dynamodb.version>
         <aws-java-sdk-ses.version>1.11.845</aws-java-sdk-ses.version>
 
-        <jackson-databind-aws-sdk-java.version>2.10.0</jackson-databind-aws-sdk-java.version>
         <lombok.version>1.18.12</lombok.version>
 
         <deltaspike.version>1.9.4</deltaspike.version>
@@ -129,13 +128,6 @@
                 <groupId>org.twitter4j</groupId>
                 <artifactId>twitter4j-core</artifactId>
                 <version>${twitter4j.version}</version>
-            </dependency>
-
-            <!-- Jackson -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind-aws-sdk-java.version}</version>
             </dependency>
 
             <!-- hawt.io -->


### PR DESCRIPTION
The jackson-databind dependency is overriding, and downgrading, the already updated version from the 'safe' wrapped version of the AWS SDK.